### PR TITLE
✨ Add support for "linked" RollTables in `sceneCues`

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -77,7 +77,9 @@
     "StatusTooltip": "<p>Use \"Shift + Click\" to increase the value.</p><p>Use \"Alt/Options + Click\" to decrease the value.</p>",
     "LuckyCoinTooltip": "<p>Use \"Shift + Click\" on the coin to increase the value.</p><p>Use \"Alt/Options + Click\" on the coin to decrease the value.</p>",
     "NicknameTooltip": "<p>Use \"Click\" to mark the nickname as used, if you have one.</p><p>Use \"Alt/Options + Click\" to mark it as unused.</p>",
-    "SceneCuesTooltip":"<p>Use \"Right Click\" to edit/delete.</p><p>Use \"Click\" to use the scene cue, if you have available usages.</p>"
+    "SceneCuesTooltip":"<p>Use \"Right Click\" to edit/delete.</p><p>Use \"Click\" to use the scene cue, if you have available usages.</p>",
+    "InfluenceTooltip": "<p>In <strong>Flabbergasted - Mystified</strong></p> <p>Certain scene cues dabble with the <em>metaphysical</em>, a realm fraught with inherent risks. When dabbling with the unknown, one risks the intrusion of external influences that might temporarily meddle with one’s personality, behaviour, or even mastery over one’s own body.</p> <p> Pasting the rollable table’s UUID into this field will automatically draw a result from the <strong>Influence Table</strong> whenever this Scene Cue is triggered. </p> <p> For standard Scene Cues, you can leave this field blank.</p>",
+    "InfluenceField": "Influence Rollable Table UUID"
   },
   "TYPES": {
     "Actor": {

--- a/module/data/item-scene-cue.mjs
+++ b/module/data/item-scene-cue.mjs
@@ -24,14 +24,7 @@ export default class FlabbergastedSceneCue extends FlabbergastedItemBase {
 
     // add "influence field"
     schema.influence = new fields.DocumentUUIDField({
-      type: "RollTable",
-      validate: uuid => {
-        // relying on DocumentUUIDField's validationError
-        /*
-        const {type, id, collection} = foundry.utils.parseUuid(uuid) ?? {};
-        if ( collection || foundry.data.validators.isValidId(id) ) { return uuid; }
-        */
-      }
+      type: "RollTable"
     });
 
     return schema;

--- a/module/data/item-scene-cue.mjs
+++ b/module/data/item-scene-cue.mjs
@@ -8,7 +8,6 @@ export default class FlabbergastedSceneCue extends FlabbergastedItemBase {
     const fields = foundry.data.fields;
     const schema = super.defineSchema();
 
-
     schema.socialStanding = new fields.NumberField({ ...DATA_COMMON.requiredInteger, initial: 0, min: -1, max: 1 });
     schema.maxUsage = new fields.NumberField({ ...DATA_COMMON.requiredInteger, initial: 0, min: 0, max: 3 });
     schema.availableUsage = new fields.NumberField({ ...DATA_COMMON.requiredInteger, initial: 0, min: 0, max: 3 });
@@ -45,7 +44,6 @@ export default class FlabbergastedSceneCue extends FlabbergastedItemBase {
 
   async roll(actor, eventType) {
     const item = this.parent;
-    let hasInflu = foundry.utils.parseUuid(item.system.influence);
 
     if (eventType == 1) {
       let value = Math.min(item.system.maxUsage, item.system.availableUsage + 1);
@@ -93,10 +91,16 @@ export default class FlabbergastedSceneCue extends FlabbergastedItemBase {
       content: content,
     });
 
-    // Influence Roll here
-    if ( hasInflu )
-      await ( await fromUuid(hasInflu.uuid)).draw({rollMode: CONST.DICE_ROLL_MODES.PRIVATE} );  
-
     console.log(actor.system.socialStanding);
+
+    // Influence Roll here
+    if (!item.system.influence)
+      return;
+      
+    const table = await fromUuid(item.system.influence);
+    if (!table)
+      return ui.notifications.error("Influence Roll table not found");
+      
+    return table.draw();
   }
 }

--- a/module/data/item-scene-cue.mjs
+++ b/module/data/item-scene-cue.mjs
@@ -7,13 +7,7 @@ export default class FlabbergastedSceneCue extends FlabbergastedItemBase {
   static defineSchema() {
     const fields = foundry.data.fields;
     const schema = super.defineSchema();
-
-    function isDocument(value) {
-      const {id, collection, uuid} = foundry.utils.parseUuid(value) ?? {};
-      if (!id || !collection) return false;
-      console.error(uuid);
-      return true;
-    }
+    
 
     schema.socialStanding = new fields.NumberField({ ...DATA_COMMON.requiredInteger, initial: 0, min: -1, max: 1 });
     schema.maxUsage = new fields.NumberField({ ...DATA_COMMON.requiredInteger, initial: 0, min: 0, max: 3 });

--- a/module/data/item-scene-cue.mjs
+++ b/module/data/item-scene-cue.mjs
@@ -7,7 +7,7 @@ export default class FlabbergastedSceneCue extends FlabbergastedItemBase {
   static defineSchema() {
     const fields = foundry.data.fields;
     const schema = super.defineSchema();
-    
+
 
     schema.socialStanding = new fields.NumberField({ ...DATA_COMMON.requiredInteger, initial: 0, min: -1, max: 1 });
     schema.maxUsage = new fields.NumberField({ ...DATA_COMMON.requiredInteger, initial: 0, min: 0, max: 3 });
@@ -25,8 +25,13 @@ export default class FlabbergastedSceneCue extends FlabbergastedItemBase {
     // add "influence field"
     schema.influence = new fields.DocumentUUIDField({
       type: "RollTable",
-      // validate: value => isDocument(value),
-      validationError: `Type can only be '${this.TYPE}'.`,
+      validate: uuid => {
+        // relying on DocumentUUIDField's validationError
+        /*
+        const {type, id, collection} = foundry.utils.parseUuid(uuid) ?? {};
+        if ( collection || foundry.data.validators.isValidId(id) ) { return uuid; }
+        */
+      }
     });
 
     return schema;
@@ -95,9 +100,9 @@ export default class FlabbergastedSceneCue extends FlabbergastedItemBase {
       content: content,
     });
 
-    // TODO: verify existence and type; use validationError
+    // Influence Roll here
     if ( hasInflu )
-      await (await fromUuid(hasInflu.uuid)).draw({rollMode: CONST.DICE_ROLL_MODES.PRIVATE});  
+      await ( await fromUuid(hasInflu.uuid)).draw({rollMode: CONST.DICE_ROLL_MODES.PRIVATE} );  
 
     console.log(actor.system.socialStanding);
   }

--- a/templates/item/item-sceneCue-sheet.hbs
+++ b/templates/item/item-sceneCue-sheet.hbs
@@ -78,6 +78,15 @@
         </div>
       </div>
       {{/if}}
+        <div class='resource form-group'>
+          <div class="info" style="max-width: 28px; flex-basis: 0; flex-grow: 1;">
+            <label class="resource-label"><i class="fa-solid fa-circle-info" style="margin-left:5px;" data-tooltip="{{localize "FLABBERGASTED.InfluenceTooltip"}}"></i></label>
+          </div>
+          <label class="resource-label">{{ localize "FLABBERGASTED.InfluenceField" }}</label>
+          <div class='form-fields'>
+            <input type="text" name="system.influence" value='{{system.influence}}' data-dtype='text'>
+          </div>
+        </div>
     </div>
   </section>
 </form>

--- a/templates/item/item-sceneCue-sheet.hbs
+++ b/templates/item/item-sceneCue-sheet.hbs
@@ -80,7 +80,7 @@
       {{/if}}
         <div class='resource form-group'>
           <div class="info" style="max-width: 28px; flex-basis: 0; flex-grow: 1;">
-            <label class="resource-label"><i class="fa-solid fa-circle-info" style="margin-left:5px;" data-tooltip="{{localize "FLABBERGASTED.InfluenceTooltip"}}"></i></label>
+            <label class="resource-label"><i class="fa-solid fa-circle-info" style="margin-left:5px;" data-tooltip-html="{{localize "FLABBERGASTED.InfluenceTooltip"}}"></i></label>
           </div>
           <label class="resource-label">{{ localize "FLABBERGASTED.InfluenceField" }}</label>
           <div class='form-fields'>


### PR DESCRIPTION
# Description
Adds support for `sceneCue` items that require an additional roll from a Rollable Table.

`sceneCue` items can now include a rollable table UUID. When the scene cue is rolled, the "linked" table will automatically draw its result after the `scene-cue` roll.

<img width="1047" height="927" alt="image" src="https://github.com/user-attachments/assets/92317169-22ba-48e7-aede-5e44bc7382ca" />

If the field is left blank, the `scene-cue` behaves normally and only the main roll is performed.

<img width="1047" height="927" alt="image" src="https://github.com/user-attachments/assets/24f30ca9-658a-40f7-8e62-97793302e517" />