### PR TITLE
fix typo in for `EFFECT.TabDuration`

### DIFF
--- a/templates/item/parts/item-effects.hbs
+++ b/templates/item/parts/item-effects.hbs
@@ -3,7 +3,7 @@
     <li class="items-header flexrow" data-effect-type="{{section.type}}">
       <h3 class="item-name effect-name flexrow">{{localize section.label}}</h3>
       <div class="effect-source">{{localize "FLABBERGASTED.Effect.Source"}}</div>
-      <div class="effect-source">{{localize "EFFECT.TabDuration"}}</div>
+      <div class="effect-source">{{localize "EFFECT.TABS.duration"}}</div>
       <div class="item-controls effect-controls flexrow">
         <a class="effect-control" data-action="create" title="{{localize 'DOCUMENT.Create' type="Effect"}}">
           <i class="fas fa-plus"></i> {{localize "DOCUMENT.New" type="Effect"}}


### PR DESCRIPTION
Fixes typo in `item-effects.hbs`:
<img width="562" height="438" alt="Screenshot From 2025-11-25 12-01-48" src="https://github.com/user-attachments/assets/f583c1cb-dc05-4fa3-ba08-b9be4c14524a" />
<img width="559" height="453" alt="Screenshot From 2025-11-25 12-16-52" src="https://github.com/user-attachments/assets/9153c9a3-f4cc-432f-9be0-dfa2d5e8fe62" />
