### PR TITLE
show influence roll indicator on scene-cues inside actor sheets

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -22,6 +22,7 @@
         "MaxUsage": "Max Usages",
         "AvailableUsage": "Available Usages",
         "Used": "Used",
+        "RollInfluence": "Roll for Influence",
         "HasExtraItem": "Has Extra Items",
         "Item": "Item {item}"
       }

--- a/templates/actor/parts/actor-sceneCues.hbs
+++ b/templates/actor/parts/actor-sceneCues.hbs
@@ -44,6 +44,8 @@
     {{#if item.system.socialStanding}}<div style="float:right; font-size: 60%; margin-top:10px">[
       <strong>+{{localize (concat "FLABBERGASTED.Item.SceneCue.SocialStandingChange." item.system.socialStanding)}}</strong> ]
     </div>{{/if}}
+    {{#if item.system.influence}}<div style="float:right; font-size: 60%; margin-top:10px;">[ <strong>{{localize "FLABBERGASTED.Item.SceneCue.RollInfluence"}}</strong> ]</div>
+    {{/if}}
   </h2>
   {{{item.system.description}}}
   {{#if item.system.hasExtraItems}}


### PR DESCRIPTION
Show influence roll for `scene-cues` inside actors:
<img width="719" height="569" alt="image" src="https://github.com/user-attachments/assets/bec12de2-fb1f-4dc2-88a2-eb2bd6c3cbc9" />
